### PR TITLE
Agressive Guards.

### DIFF
--- a/DayZExpansion/AI/Scripts/3_Game/DayZExpansion_AI/Factions/eAIFaction.c
+++ b/DayZExpansion/AI/Scripts/3_Game/DayZExpansion_AI/Factions/eAIFaction.c
@@ -3,6 +3,7 @@ class eAIFaction
 	protected string m_Name;  //! DEPRECATED
 	protected string m_Loadout = "HumanLoadout";
 	protected bool m_IsGuard;
+	protected bool m_IsAggressiveGuard;
 	protected bool m_IsInvincible;
 	protected bool m_IsPassive;
 	protected bool m_IsObserver;
@@ -74,6 +75,11 @@ class eAIFaction
 	bool IsGuard()
 	{
 		return m_IsGuard;
+	}
+
+	bool IsAggressiveGuard()
+	{
+		return IsGuard() && m_IsAggressiveGuard;
 	}
 
 	bool IsInvincible()

--- a/DayZExpansion/AI/Scripts/4_World/DayZExpansion_AI/Classes/Targets/eAIPlayerTargetInformation.c
+++ b/DayZExpansion/AI/Scripts/4_World/DayZExpansion_AI/Classes/Targets/eAIPlayerTargetInformation.c
@@ -62,23 +62,20 @@ class eAIPlayerTargetInformation: eAIEntityTargetInformation
 			{
 				bool canEnterFightingState;
 
-				if (ai.GetGroup().GetFaction().IsGuard())
+				if (ai.GetGroup().GetFaction().IsGuard() && !ai.PlayerIsEnemy(m_Player, false, isPlayerMoving))
 				{
-					//! Apply common Guard logic, if current AI is NOT agressive guard OR player is friendly to agressive guardian
-					if (!ai.GetGroup().GetFaction().IsGuardAgressive() || (ai.GetGroup().GetFaction().IsGuardAgressive() && !ai.PlayerIsEnemy(m_Player))) {
-
-						if (m_Player.IsRaised() && fromTargetDot >= 0.9 && ((enemyHands && enemyHands.IsWeapon()) || m_Player.IsFighting()))
-							canEnterFightingState = true;
-						else if (m_Player.eAI_UpdateAgressionTimeout(150.0 - distance))
-							canEnterFightingState = true;
-	
-						if (!canEnterFightingState && m_Player.IsRaised())
-						{
-							//! They aim at you
-							return ExpansionMath.PowerConversion(0.5, 30, distance, 0.2, 0.0, 0.1);
-						}
-					} else {
+					if (m_Player.IsRaised() && fromTargetDot >= 0.9 && ((enemyHands && enemyHands.IsWeapon()) || m_Player.IsFighting()))
+					{
 						canEnterFightingState = true;
+					}
+					else if (m_Player.eAI_UpdateAgressionTimeout(150.0 - distance)) {
+						canEnterFightingState = true;
+					}
+
+					if (!canEnterFightingState && m_Player.IsRaised())
+					{
+						//! They aim at you
+						return ExpansionMath.PowerConversion(0.5, 30, distance, 0.2, 0.0, 0.1);
 					}
 				}
 				else if (!ai.GetGroup().GetFaction().IsObserver() && !m_Player.Expansion_IsInSafeZone())

--- a/DayZExpansion/AI/Scripts/4_World/DayZExpansion_AI/Classes/Targets/eAIPlayerTargetInformation.c
+++ b/DayZExpansion/AI/Scripts/4_World/DayZExpansion_AI/Classes/Targets/eAIPlayerTargetInformation.c
@@ -38,8 +38,9 @@ class eAIPlayerTargetInformation: eAIEntityTargetInformation
 					return levelFactor;
 			}
 
+			//! Check if player is enemy and return if not, except if current AI is Agressive Guard
 			bool isPlayerMoving;
-			if (!ai.PlayerIsEnemy(m_Player, false, isPlayerMoving))
+			if (!ai.PlayerIsEnemy(m_Player, false, isPlayerMoving) && !ai.GetGroup().GetFaction().IsGuardAgressive())
 			{
 				//! They eyeball you menacingly if you move, or if another friendly AI moves that is not in same group
 				if (isPlayerMoving && (!m_Player.IsAI() || m_Player.GetGroup() != ai.GetGroup()))
@@ -63,15 +64,21 @@ class eAIPlayerTargetInformation: eAIEntityTargetInformation
 
 				if (ai.GetGroup().GetFaction().IsGuard())
 				{
-					if (m_Player.IsRaised() && fromTargetDot >= 0.9 && ((enemyHands && enemyHands.IsWeapon()) || m_Player.IsFighting()))
-						canEnterFightingState = true;
-					else if (m_Player.eAI_UpdateAgressionTimeout(150.0 - distance))
-						canEnterFightingState = true;
+					//! Apply common Guard logic, if current AI is NOT agressive guard OR player is friendly to agressive guardian
+					if (!ai.GetGroup().GetFaction().IsGuardAgressive() || (ai.GetGroup().GetFaction().IsGuardAgressive() && !ai.PlayerIsEnemy(m_Player))) {
 
-					if (!canEnterFightingState && m_Player.IsRaised())
-					{
-						//! They aim at you
-						return ExpansionMath.PowerConversion(0.5, 30, distance, 0.2, 0.0, 0.1);
+						if (m_Player.IsRaised() && fromTargetDot >= 0.9 && ((enemyHands && enemyHands.IsWeapon()) || m_Player.IsFighting()))
+							canEnterFightingState = true;
+						else if (m_Player.eAI_UpdateAgressionTimeout(150.0 - distance))
+							canEnterFightingState = true;
+	
+						if (!canEnterFightingState && m_Player.IsRaised())
+						{
+							//! They aim at you
+							return ExpansionMath.PowerConversion(0.5, 30, distance, 0.2, 0.0, 0.1);
+						}
+					} else {
+						canEnterFightingState = true;
 					}
 				}
 				else if (!ai.GetGroup().GetFaction().IsObserver() && !m_Player.Expansion_IsInSafeZone())

--- a/DayZExpansion/AI/Scripts/4_World/DayZExpansion_AI/Entities/AI/eAIBase.c
+++ b/DayZExpansion/AI/Scripts/4_World/DayZExpansion_AI/Entities/AI/eAIBase.c
@@ -424,11 +424,9 @@ class eAIBase: PlayerBase
 		}
 
 		//! Agressive guards are always agressive to not friendly players/factions
-		if (GetGroup().GetFaction().IsGuardAgressive()) {
-            if (!GetGroup().GetFaction().IsFriendly(player) && !GetGroup().GetFaction().IsFriendly(player.GetGroup().GetFaction())) {
-                return true;
-            }
-        }
+		if (GetGroup().GetFaction().IsGuardAgressive() && !GetGroup().GetFaction().IsFriendly(player) && !GetGroup().GetFaction().IsFriendly(player.GetGroup().GetFaction())) {
+	            return true;
+	        }
 
 		//! Are we targeting them and aggro?
 		bool targeted;

--- a/DayZExpansion/AI/Scripts/4_World/DayZExpansion_AI/Entities/AI/eAIBase.c
+++ b/DayZExpansion/AI/Scripts/4_World/DayZExpansion_AI/Entities/AI/eAIBase.c
@@ -423,6 +423,13 @@ class eAIBase: PlayerBase
 			return isPlayerMoving;
 		}
 
+		//! Agressive guards are always agressive to not friendly players/factions
+		if (GetGroup().GetFaction().IsGuardAgressive()) {
+            if (!GetGroup().GetFaction().IsFriendly(player) && !GetGroup().GetFaction().IsFriendly(player.GetGroup().GetFaction())) {
+                return true;
+            }
+        }
+
 		//! Are we targeting them and aggro?
 		bool targeted;
 		if (eAI_GetTargetThreat(player.GetTargetInformation(), true) > 0.2)


### PR DESCRIPTION
Hi. Suggestion in Discord link: https://discord.com/channels/523890175563137034/1178181438747705406/1178181438747705406

What modules does it touch:
- DayZ-Expansion-AI

What is feature of this PR:
Adds a new configurable parameter to Guards factions. If `m_IsAggressiveGuard` is set to true, Guard behaviour is changed to:
- Attack non friendly units.
- Behave like normal Gaurds to friendly units.

What is current known problems which need to be fixed:
- Friendly player not seeing aggro timer.
- If there is two or more Patrols nearby or patrol contains more than one AI - they won't aggro on a gun raise and only one AI (victim) will attack you, if you attack him.
