### PR TITLE
Bugfix/travel event

### DIFF
--- a/DayZExpansion/Quests/Scripts/4_World/DayZExpansion_Quests/Systems/Quests/QuestObjectiveEvents/ExpansionQuestObjectiveTravelEvent.c
+++ b/DayZExpansion/Quests/Scripts/4_World/DayZExpansion_Quests/Systems/Quests/QuestObjectiveEvents/ExpansionQuestObjectiveTravelEvent.c
@@ -57,7 +57,7 @@ class ExpansionQuestObjectiveTravelEvent: ExpansionQuestObjectiveEventBase
 		}
 
 		#ifdef EXPANSIONMODNAVIGATION
-		if (m_TravelConfig.GetMarkerName() != string.Empty)
+		if (CanCreateMarkers())
 			CreateMarkers();
 		#endif
 
@@ -266,6 +266,9 @@ class ExpansionQuestObjectiveTravelEvent: ExpansionQuestObjectiveEventBase
 #ifdef EXPANSIONMODNAVIGATION
 	override bool CanCreateMarkers()
 	{
+		if (m_TravelConfig.GetMarkerName() == string.Empty) {
+			return false;
+		}
 		return !m_DestinationReached;
 	}
 #endif


### PR DESCRIPTION
There is a bug for travel objectives with empty MarkerName - according to docs, there should be no marker for this objectives, but anyway it exists. The problem is in ExpansionQuestObjectiveTravelEvent::CanCreateMarkers missing check for MarkerName == string.empty.