### PR TITLE
Some splits for better modding options

### DIFF
--- a/DayZExpansion/AI/Scripts/4_World/DayZExpansion_AI/Classes/Patrols/eAIDynamicPatrol.c
+++ b/DayZExpansion/AI/Scripts/4_World/DayZExpansion_AI/Classes/Patrols/eAIDynamicPatrol.c
@@ -133,8 +133,18 @@ class eAIDynamicPatrol : eAIPatrol
 		pos = ExpansionAIPatrol.GetPlacementPosition(pos);
 
 		eAIBase ai;
-		if (!Class.CastTo(ai, GetGame().CreateObject(GetRandomAI(), pos))) return null;
+		if (!Class.CastTo(ai, CreateAIEntity(pos))) return null;
 
+		ConfigureAi(ai, pos);
+
+		return ai;
+	}
+
+	private Object CreateAIEntity(vector pos) {
+		return GetGame().CreateObject(GetRandomAI(), pos);
+	}
+
+	private void ConfigureAi(eAIBase ai, vector pos) {
 		ai.SetPosition(pos);
 
 		if ( m_Loadout == "" )
@@ -150,8 +160,6 @@ class eAIDynamicPatrol : eAIPatrol
 		ai.eAI_SetNoiseInvestigationDistanceLimit(m_NoiseInvestigationDistanceLimit);
 		ai.eAI_SetDamageMultiplier(m_DamageMultiplier);
 		ai.eAI_SetSniperProneDistanceThreshold(m_SniperProneDistanceThreshold);
-
-		return ai;
 	}
 
 	bool WasGroupDestroyed()


### PR DESCRIPTION
Hello.
Recently i've tried to add some options to spawned patrols, and one caused a problem - i wanted to add an options to spawn only male or only female AIs via my mod configuration. But to accomplish that - i need to fully override or copy `SpawnAI` method which causes obvious problem - it can break Expansion functionality after some of your updates. 

So i took all my bravery to send you this PR. It's just splits `SpawnAI` to few separated methods.

If you won't accept this one, maybe i can send you a PR with male/female functionality?