### PR TITLE
Fix ExpansionSpraycanYellow using blue texture

### DIFF
--- a/DayZExpansion/Vehicles/Ground/LandRover/config.cpp
+++ b/DayZExpansion/Vehicles/Ground/LandRover/config.cpp
@@ -2894,7 +2894,7 @@ class CfgVehicles
 		descriptionShort="$STR_EXPANSION_SPRAYCAN_Yellow_DESC";
 		hiddenSelectionsTextures[]=
 		{
-			"\DayzExpansion\Objects\Gear\Spraycans\data\spraycan_blue_co.paa"
+			"\DayzExpansion\Objects\Gear\Spraycans\data\spraycan_yellow_co.paa"
 		};
 		skinName="Yellow";
 	};


### PR DESCRIPTION
ExpansionSpraycanYellow currently references the blue spraycan texture in the Land Rover config. This switches it to the yellow spraycan texture.